### PR TITLE
🎉 Release 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- 🎉 Release 0.0.1 [[#6](https://github.com/FrederikBRoth/cv-adventure/pull/6)]
+- 🎉 Release 0.0.1 [[#6](https://github.com/FrederikBRoth/cv-adventure/pull/6)]
 - New stuff [[#7](https://github.com/FrederikBRoth/cv-adventure/pull/7)]
 - New stuff [[#7](https://github.com/FrederikBRoth/cv-adventure/pull/7)]
 - 🎉 Release 0.0.1 [[#5](https://github.com/FrederikBRoth/cv-adventure/pull/5)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 
 @FrederikBRoth
 
+### 🐛 Bug Fixes
+
+- again [[#10](https://github.com/FrederikBRoth/cv-adventure/pull/10)]
+
 ### Misc
 
+- again [[#9](https://github.com/FrederikBRoth/cv-adventure/pull/9)]
 - 🎉 Release 0.0.1 [[#6](https://github.com/FrederikBRoth/cv-adventure/pull/6)]
 - 🎉 Release 0.0.1 [[#6](https://github.com/FrederikBRoth/cv-adventure/pull/6)]
 - New stuff [[#7](https://github.com/FrederikBRoth/cv-adventure/pull/7)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.0.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.0.1](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.0.1) - 2024-07-19

### 🐛 Bug Fixes

- again [[#10](https://github.com/FrederikBRoth/cv-adventure/pull/10)]

### Misc

- again [[#9](https://github.com/FrederikBRoth/cv-adventure/pull/9)]
- 🎉 Release 0.0.1 [[#6](https://github.com/FrederikBRoth/cv-adventure/pull/6)]
- 🎉 Release 0.0.1 [[#6](https://github.com/FrederikBRoth/cv-adventure/pull/6)]
- New stuff [[#7](https://github.com/FrederikBRoth/cv-adventure/pull/7)]
- New stuff [[#7](https://github.com/FrederikBRoth/cv-adventure/pull/7)]
- 🎉 Release 0.0.1 [[#5](https://github.com/FrederikBRoth/cv-adventure/pull/5)]
- 🎉 Release 0.0.1 [[#4](https://github.com/FrederikBRoth/cv-adventure/pull/4)]
- 🎉 Release 0.0.1 [[#3](https://github.com/FrederikBRoth/cv-adventure/pull/3)]
- 🎉 Release 0.0.1 [[#2](https://github.com/FrederikBRoth/cv-adventure/pull/2)]
- Dev [[#1](https://github.com/FrederikBRoth/cv-adventure/pull/1)]
- Dev [[#1](https://github.com/FrederikBRoth/cv-adventure/pull/1)]
- Dev [[#1](https://github.com/FrederikBRoth/cv-adventure/pull/1)]