### PR TITLE
🎉 Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.2](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.2) - 2024-07-19
+## [0.1.2](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.2) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Dev [[#33](https://github.com/FrederikBRoth/cv-adventure/pull/33)]
 - lmao :D [[#31](https://github.com/FrederikBRoth/cv-adventure/pull/31)]
 
 ## [0.1.1](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.1) - 2024-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.1](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.1) - 2024-07-19
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- new addition!! [[#29](https://github.com/FrederikBRoth/cv-adventure/pull/29)]
+- new addition!! [[#29](https://github.com/FrederikBRoth/cv-adventure/pull/29)]
+
 ## [0.1.0](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.0) - 2024-07-19
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.2](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.2) - 2024-07-19
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- lmao :D [[#31](https://github.com/FrederikBRoth/cv-adventure/pull/31)]
+
 ## [0.1.1](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.1) - 2024-07-19
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Misc
 
+- 🎉 Release 0.1.0 [[#27](https://github.com/FrederikBRoth/cv-adventure/pull/27)]
 - 🎉 Release 0.1.0 [[#25](https://github.com/FrederikBRoth/cv-adventure/pull/25)]
 - 🎉 Release 0.0.1 [[#23](https://github.com/FrederikBRoth/cv-adventure/pull/23)]
 - Updated pipeline [[#22](https://github.com/FrederikBRoth/cv-adventure/pull/22)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.2` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.2](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.2) - 2024-07-20

### Misc

- Dev [[#33](https://github.com/FrederikBRoth/cv-adventure/pull/33)]
- lmao :D [[#31](https://github.com/FrederikBRoth/cv-adventure/pull/31)]