### PR TITLE
🎉 Release 0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.13](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.13) - 2024-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- fuck [[#60](https://github.com/FrederikBRoth/cv-adventure/pull/60)]
+
 ## [0.1.12](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.12) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.11](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.11) - 2024-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Dev [[#56](https://github.com/FrederikBRoth/cv-adventure/pull/56)]
+
 ## [0.1.10](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.10) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.9](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.9) - 2024-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- ad [[#52](https://github.com/FrederikBRoth/cv-adventure/pull/52)]
+
 ## [0.1.8](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.8) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.10](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.10) - 2024-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Dev [[#54](https://github.com/FrederikBRoth/cv-adventure/pull/54)]
+
 ## [0.1.9](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.9) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.12](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.12) - 2024-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Dev [[#58](https://github.com/FrederikBRoth/cv-adventure/pull/58)]
+- Dev [[#58](https://github.com/FrederikBRoth/cv-adventure/pull/58)]
+- Dev [[#58](https://github.com/FrederikBRoth/cv-adventure/pull/58)]
+- Dev [[#56](https://github.com/FrederikBRoth/cv-adventure/pull/56)]
+- Dev [[#56](https://github.com/FrederikBRoth/cv-adventure/pull/56)]
+- Dev [[#54](https://github.com/FrederikBRoth/cv-adventure/pull/54)]
+- ad [[#52](https://github.com/FrederikBRoth/cv-adventure/pull/52)]
+- ad [[#52](https://github.com/FrederikBRoth/cv-adventure/pull/52)]
+
 ## [0.1.11](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.11) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.8](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.8) - 2024-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Dev [[#50](https://github.com/FrederikBRoth/cv-adventure/pull/50)]
+- Dev [[#50](https://github.com/FrederikBRoth/cv-adventure/pull/50)]
+- Dev [[#50](https://github.com/FrederikBRoth/cv-adventure/pull/50)]
+- Dev [[#48](https://github.com/FrederikBRoth/cv-adventure/pull/48)]
+- Dev [[#48](https://github.com/FrederikBRoth/cv-adventure/pull/48)]
+- Dev [[#46](https://github.com/FrederikBRoth/cv-adventure/pull/46)]
+- Dev [[#46](https://github.com/FrederikBRoth/cv-adventure/pull/46)]
+- pls [[#44](https://github.com/FrederikBRoth/cv-adventure/pull/44)]
+
 ## [0.1.7](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.7) - 2024-07-20
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/file.txt
+++ b/file.txt
@@ -1,0 +1,1 @@
+testinglmap


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.13` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.13](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.13) - 2024-07-20

### Misc

- fuck [[#60](https://github.com/FrederikBRoth/cv-adventure/pull/60)]