### PR TITLE
🎉 Release 0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.1.18](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.18) - 2024-07-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Dev [[#71](https://github.com/FrederikBRoth/cv-adventure/pull/71)]
+- Dev [[#71](https://github.com/FrederikBRoth/cv-adventure/pull/71)]
+- Dev [[#71](https://github.com/FrederikBRoth/cv-adventure/pull/71)]
+- Dev [[#69](https://github.com/FrederikBRoth/cv-adventure/pull/69)]
+- Dev [[#69](https://github.com/FrederikBRoth/cv-adventure/pull/69)]
+- Dev [[#68](https://github.com/FrederikBRoth/cv-adventure/pull/68)]
+- Dev [[#68](https://github.com/FrederikBRoth/cv-adventure/pull/68)]
+- Working maybe [[#66](https://github.com/FrederikBRoth/cv-adventure/pull/66)]
+- Dev [[#64](https://github.com/FrederikBRoth/cv-adventure/pull/64)]
+- Dev [[#62](https://github.com/FrederikBRoth/cv-adventure/pull/62)]
+- Dev [[#62](https://github.com/FrederikBRoth/cv-adventure/pull/62)]
+- fuck [[#60](https://github.com/FrederikBRoth/cv-adventure/pull/60)]
+
 ## [0.1.17](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.17) - 2024-07-22
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.18` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.18](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.18) - 2024-07-22

### Misc

- Dev [[#71](https://github.com/FrederikBRoth/cv-adventure/pull/71)]
- Dev [[#71](https://github.com/FrederikBRoth/cv-adventure/pull/71)]
- Dev [[#71](https://github.com/FrederikBRoth/cv-adventure/pull/71)]
- Dev [[#69](https://github.com/FrederikBRoth/cv-adventure/pull/69)]
- Dev [[#69](https://github.com/FrederikBRoth/cv-adventure/pull/69)]
- Dev [[#68](https://github.com/FrederikBRoth/cv-adventure/pull/68)]
- Dev [[#68](https://github.com/FrederikBRoth/cv-adventure/pull/68)]
- Working maybe [[#66](https://github.com/FrederikBRoth/cv-adventure/pull/66)]
- Dev [[#64](https://github.com/FrederikBRoth/cv-adventure/pull/64)]
- Dev [[#62](https://github.com/FrederikBRoth/cv-adventure/pull/62)]
- Dev [[#62](https://github.com/FrederikBRoth/cv-adventure/pull/62)]
- fuck [[#60](https://github.com/FrederikBRoth/cv-adventure/pull/60)]