### PR TITLE
🎉 Release 0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.20](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.20) - 2024-07-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Add another release edit step for webhook triger [[#75](https://github.com/FrederikBRoth/cv-adventure/pull/75)]
+
 ## [0.1.19](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.19) - 2024-07-22
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.20` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.20](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.20) - 2024-07-22

### Misc

- Add another release edit step for webhook triger [[#75](https://github.com/FrederikBRoth/cv-adventure/pull/75)]