### PR TITLE
🎉 Release 0.1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.26](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.26) - 2024-07-25
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Working dropin video [[#87](https://github.com/FrederikBRoth/cv-adventure/pull/87)]
+
 ## [0.1.25](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.25) - 2024-07-23
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.25](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.25) - 2024-07-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Top bar with signals working [[#85](https://github.com/FrederikBRoth/cv-adventure/pull/85)]
+
 ## [0.1.24](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.24) - 2024-07-23
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.26` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.26](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.26) - 2024-07-25

### Misc

- Working dropin video [[#87](https://github.com/FrederikBRoth/cv-adventure/pull/87)]