### PR TITLE
🎉 Release 0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.29](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.29) - 2024-08-01
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Newfix [[#93](https://github.com/FrederikBRoth/cv-adventure/pull/93)]
+
 ## [0.1.28](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.28) - 2024-08-01
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.30](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.30) - 2024-08-01
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Shit [[#95](https://github.com/FrederikBRoth/cv-adventure/pull/95)]
+
 ## [0.1.29](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.29) - 2024-08-01
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.30` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.30](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.30) - 2024-08-01

### Misc

- Shit [[#95](https://github.com/FrederikBRoth/cv-adventure/pull/95)]