### PR TITLE
🎉 Release 0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update tag.yml [[#111](https://github.com/FrederikBRoth/cv-adventure/pull/111)]
 - Update release.yml [[#109](https://github.com/FrederikBRoth/cv-adventure/pull/109)]
 - Update release.yml [[#108](https://github.com/FrederikBRoth/cv-adventure/pull/108)]
 - Update release.yml [[#107](https://github.com/FrederikBRoth/cv-adventure/pull/107)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.34` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.34](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.34) - 2025-07-20

### Misc

- Update tag.yml [[#111](https://github.com/FrederikBRoth/cv-adventure/pull/111)]
- Update release.yml [[#109](https://github.com/FrederikBRoth/cv-adventure/pull/109)]
- Update release.yml [[#108](https://github.com/FrederikBRoth/cv-adventure/pull/108)]
- Update release.yml [[#107](https://github.com/FrederikBRoth/cv-adventure/pull/107)]
- Update release.yml [[#106](https://github.com/FrederikBRoth/cv-adventure/pull/106)]
- Update README.md [[#105](https://github.com/FrederikBRoth/cv-adventure/pull/105)]
- Update README.md [[#104](https://github.com/FrederikBRoth/cv-adventure/pull/104)]
- Update README.md [[#103](https://github.com/FrederikBRoth/cv-adventure/pull/103)]