### PR TITLE
🎉 Release 0.1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Specify config file [[#124](https://github.com/FrederikBRoth/cv-adventure/pull/124)]
 - Update README.md [[#122](https://github.com/FrederikBRoth/cv-adventure/pull/122)]
 - Update tag.yml [[#121](https://github.com/FrederikBRoth/cv-adventure/pull/121)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.38](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.38) - 2025-07-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Update README.md [[#122](https://github.com/FrederikBRoth/cv-adventure/pull/122)]
+- Update tag.yml [[#121](https://github.com/FrederikBRoth/cv-adventure/pull/121)]
+
 ## [0.1.37](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.37) - 2025-07-20
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.38` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.38](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.38) - 2025-07-20

### Misc

- Specify config file [[#124](https://github.com/FrederikBRoth/cv-adventure/pull/124)]
- Update README.md [[#122](https://github.com/FrederikBRoth/cv-adventure/pull/122)]
- Update tag.yml [[#121](https://github.com/FrederikBRoth/cv-adventure/pull/121)]