### PR TITLE
🎉 Release 0.1.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.51](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.51) - 2025-07-24
+
+### ❤️ Thanks to all contributors! ❤️
+
+@FrederikBRoth
+
+### Misc
+
+- Update tag.yml [[#152](https://github.com/FrederikBRoth/cv-adventure/pull/152)]
+
 ## [0.1.50](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.50) - 2025-07-24
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.51` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.51](https://github.com/FrederikBRoth/cv-adventure/releases/tag/0.1.51) - 2025-07-24

### Misc

- Update tag.yml [[#152](https://github.com/FrederikBRoth/cv-adventure/pull/152)]